### PR TITLE
Port certlib from cloudnatix

### DIFF
--- a/pkg/certlib/store/doc.go
+++ b/pkg/certlib/store/doc.go
@@ -1,0 +1,4 @@
+// Package store provides various implementations of stores of TLS certificates
+// that can be plugged into server libraries that accept tls.Config structs
+// (e.g. the http and grpc packages).
+package store

--- a/pkg/certlib/store/reload.go
+++ b/pkg/certlib/store/reload.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+const defaultReloadInterval = time.Hour
+
+// ReloadingFileStoreOpts are options for a ReloadingFileStore.
+type ReloadingFileStoreOpts struct {
+	KeyPath        string
+	CertPath       string
+	ReloadInterval time.Duration
+}
+
+// ReloadingFileStore is a Store that will return the same tls.Certificate for
+// all incoming TLS handshakes. The certificate is periodically regenerated
+// by loading the key material from a well known path.
+type ReloadingFileStore struct {
+	keyPath  string
+	certPath string
+	t        <-chan time.Time
+	m        sync.RWMutex
+	cert     *tls.Certificate
+}
+
+// NewReloadingFileStore returns a pointer to a new ReloadingFileStore.
+func NewReloadingFileStore(opts ReloadingFileStoreOpts) (*ReloadingFileStore, error) {
+	d := defaultReloadInterval
+	if opts.ReloadInterval > 0 {
+		d = opts.ReloadInterval
+	}
+
+	s := &ReloadingFileStore{
+		keyPath:  opts.KeyPath,
+		certPath: opts.CertPath,
+		t:        time.NewTicker(d).C,
+	}
+	if err := s.reload(); err != nil {
+		return nil, fmt.Errorf("cert: new cert store: %s", err)
+	}
+	return s, nil
+}
+
+// GetCertificateFunc implements Store by returning a function that returns the
+// currently cached value of the tls.Certificate.
+func (s *ReloadingFileStore) GetCertificateFunc() func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		return s.getCert(), nil
+	}
+}
+
+// Run starts the Store, performing an initial load of the tls.Certificate
+// before entering the reload loop.
+func (s *ReloadingFileStore) Run(ctx context.Context) error {
+	log.Printf("Starting store\n")
+
+	// Perform an initial load.
+	if err := s.reload(); err != nil {
+		return err
+	}
+
+	// Enter the blocking refresh loop.
+	for {
+		select {
+		case <-s.t:
+			if err := s.reload(); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// reload loads and parses the tls.Certificate from the well known paths, and
+// updates the value of the certificate in the Store to point at this
+// (potentially, new) value.
+func (s *ReloadingFileStore) reload() error {
+	log.Printf("Performing reload: cert = %s; key = %s\n", s.certPath, s.keyPath)
+
+	cert, err := tls.LoadX509KeyPair(s.certPath, s.keyPath)
+	if err != nil {
+		return fmt.Errorf("reload: load keypair: %s", err)
+	}
+
+	s.m.Lock()
+	s.cert = &cert
+	s.m.Unlock()
+
+	log.Printf("Reload complete\n")
+	return nil
+}
+
+// getCert returns the pointer to the current tls.Certificate.
+//
+// This method should be used to fetch the certificate, rather than directly
+// accessing, given multiple goroutines can attempt to mutate the current value.
+func (s *ReloadingFileStore) getCert() *tls.Certificate {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.cert
+}

--- a/pkg/certlib/store/reload_test.go
+++ b/pkg/certlib/store/reload_test.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io/ioutil"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	keyFile  = "key.pem"
+	certFile = "crt.pem"
+)
+
+func TestNewReloadingFileStore(t *testing.T) {
+	cn1, cn2 := "example1.com", "example2.com"
+	dir := t.TempDir()
+
+	// Generate a certificate.
+	if err := genCertPair(dir, cn1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize a cert store with the new cert.
+	tickC := make(chan time.Time)
+	store := &ReloadingFileStore{
+		keyPath:  dir + "/" + keyFile,
+		certPath: dir + "/" + certFile,
+		t:        tickC,
+	}
+
+	// The cert store initially has no certificate loaded.
+	assert.Nil(t, store.getCert())
+
+	// Start the store.
+	ctx, cancel := context.WithCancel(context.Background())
+	errC := make(chan error)
+	go func() {
+		errC <- store.Run(ctx)
+	}()
+
+	// Trigger a reload.
+	tickC <- time.Now()
+
+	// The store now has a cert loaded.
+	assertCNEventually(t, cn1, store, 5*time.Second)
+
+	// Generate a new cert.
+	if err := genCertPair(dir, cn2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger a reload.
+	tickC <- time.Now()
+
+	// The new cert is different to the first.
+	assertCNEventually(t, cn2, store, 5*time.Second)
+
+	cancel()
+	assert.Equal(t, context.Canceled, <-errC)
+}
+
+// genCertPair generates and writes out a new TLS key and certificate to the
+// given directory.
+func genCertPair(dir, cn string) error {
+	key, cert, err := newCertPair(cn)
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(dir+"/"+keyFile, key, 0600); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(dir+"/"+certFile, cert, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// newCertPair constructs a new RSA key and TLS certificate and return the
+// bytes in PEM-encoded format.
+func newCertPair(cn string) ([]byte, []byte, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyBytes := x509.MarshalPKCS1PrivateKey(key)
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Minute)
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName: cn,
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyBytes = pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: keyBytes,
+	})
+
+	certBytes = pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	return keyBytes, certBytes, nil
+}
+
+// assertCNEventually asserts that the CN on the TLS certificate currently
+// loaded in to the store is equal to the expected value within the given
+// duration.
+func assertCNEventually(t *testing.T, expected string, s *ReloadingFileStore, duration time.Duration) {
+	assert.Eventually(t, func() bool {
+		c, err := x509.ParseCertificate(s.getCert().Certificate[0])
+		assert.NoError(t, err)
+		return expected == c.Subject.CommonName
+	}, duration, time.Second)
+}

--- a/pkg/certlib/store/store.go
+++ b/pkg/certlib/store/store.go
@@ -1,0 +1,17 @@
+package store
+
+import (
+	"context"
+	"crypto/tls"
+)
+
+// Store is a cache of tls.Certificates.
+type Store interface {
+
+	// GetCertificateFunc returns a function that will return the appropriate
+	// tls.Certificate based on the incoming tls.ClientHelloInfo.
+	GetCertificateFunc() func(info *tls.ClientHelloInfo) (*tls.Certificate, error)
+
+	// Run starts the Store.
+	Run(ctx context.Context) error
+}


### PR DESCRIPTION
This will be used by session-manager and inference-manager-server to use TLS in their servers. As these servers provide the endpoint without Kong, they need to handle TLS requests.